### PR TITLE
Fix "`.next_sibling` and `.previous_sibling`" example HTML

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -865,10 +865,17 @@ In real documents, the ``.next_sibling`` or ``.previous_sibling`` of a
 tag will usually be a string containing whitespace. Going back to the
 "three sisters" document::
 
- <a href="http://example.com/elsie" class="sister" id="link1">Elsie</a>
- <a href="http://example.com/lacie" class="sister" id="link2">Lacie</a>
- <a href="http://example.com/tillie" class="sister" id="link3">Tillie</a>
+   <html><head><title>The Dormouse's story</title></head>
+   <body>
+   <p class="title"><b>The Dormouse's story</b></p>
 
+   <p class="story">Once upon a time there were three little sisters; and their names were
+   <a href="http://example.com/elsie" class="sister" id="link1">Elsie</a>,
+   <a href="http://example.com/lacie" class="sister" id="link2">Lacie</a> and
+   <a href="http://example.com/tillie" class="sister" id="link3">Tillie</a>;
+   and they lived at the bottom of a well.</p>
+
+   <p class="story">...</p>
 You might think that the ``.next_sibling`` of the first <a> tag would
 be the second <a> tag. But actually, it's a string: the comma and
 newline that separate the first <a> tag from the second::


### PR DESCRIPTION
The exposition for "`.next_sibling` and `previous_sibling`" references commas that are not present in the pared down version of the "Three Sisters" example HTML shown with it.